### PR TITLE
Add pretty_print_game_state to GameInterface

### DIFF
--- a/src/boxoban_mcp/game_interface.py
+++ b/src/boxoban_mcp/game_interface.py
@@ -159,3 +159,39 @@ class GameInterface:
             The heuristic score as a float.
         """
         return self.calculate_greedy_score()
+
+    def pretty_print_game_state(self):
+        game_state_str = self.game.get_game_state()
+        if not game_state_str:
+            print("Empty game state.")
+            return
+
+        rows = game_state_str.strip().split('\n')
+        if not rows or not rows[0]:
+            print("Game state has no rows or the first row is empty.")
+            return
+
+        num_cols = len(rows[0])
+        if num_cols == 0:
+            print("Game state has rows but no columns.")
+            return
+
+        # Create the horizontal border
+        horizontal_border = "+" + "---+" * num_cols
+
+        # Print the top border
+        print(horizontal_border)
+
+        for row_str in rows:
+            # Ensure all rows are processed consistently, even if shorter than num_cols
+            # This might happen if the game state string is not perfectly rectangular,
+            # though get_game_state() from BoxobanGame should produce rectangular output.
+            # We will format based on num_cols derived from the first row.
+
+            formatted_row_parts = []
+            for i in range(num_cols):
+                char = row_str[i] if i < len(row_str) else ' ' # Use space if row is shorter
+                formatted_row_parts.append(f" {char} ")
+
+            print("|" + "|".join(formatted_row_parts) + "|")
+            print(horizontal_border)

--- a/tests/test_game_interface.py
+++ b/tests/test_game_interface.py
@@ -1,4 +1,6 @@
 import unittest
+import io
+import contextlib
 import json # Though direct json output isn't being tested for structure yet, good to have if needed.
 from src.boxoban_mcp.game import BoxobanGame
 from src.boxoban_mcp.game_interface import GameInterface
@@ -194,6 +196,34 @@ class TestGameInterface(unittest.TestCase):
         game = BoxobanGame.load_game_from_file("tests/data/iface_heuristic_no_boxes.txt")
         interface = GameInterface(game)
         self.assertEqual(interface.get_heuristic_score(), 0.0)
+
+    def test_pretty_print_game_state(self):
+        """Test the pretty_print_game_state method for correct formatting."""
+        # Board string: "##\n@.#\n##"
+        # BoxobanGame._parse_board_string pads rows. max_len will be 3.
+        # Game state becomes: "## \n@.#\n## "
+        # pretty_print_game_state uses len(rows[0]) for num_cols, so 3.
+        board_string = "##\n@.#\n##"
+        game = BoxobanGame(board_string_input=board_string) # Use board_string_input
+        interface = GameInterface(game)
+
+        expected_output_lines = [
+            "+---+---+---+",
+            "| # | # |   |",
+            "+---+---+---+",
+            "| @ | . | # |",
+            "+---+---+---+",
+            "| # | # |   |",
+            "+---+---+---+"
+        ]
+        expected_output = "\n".join(expected_output_lines) + "\n"
+
+        stdout_capture = io.StringIO()
+        with contextlib.redirect_stdout(stdout_capture):
+            interface.pretty_print_game_state()
+
+        captured_output = stdout_capture.getvalue()
+        self.assertEqual(captured_output, expected_output)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit introduces a new method `pretty_print_game_state` to the `GameInterface` class. This method allows for a visually formatted representation of the current game board state to be printed to the console.

The format is a grid with `+---+` style borders and `| X |` style cells, for example: +---+---+---+
| # | # |   |
+---+---+---+
| @ | . | # |
+---+---+---+
| # | # |   |
+---+---+---+

The implementation handles game board padding by conforming to the width of the (potentially padded) first row of the game state string.

A unit test has been added to `tests/test_game_interface.py` to verify the output of this new method against a known game state, ensuring the formatting is correct and that padding is handled as expected.